### PR TITLE
Fix the crash in GROMACS simulation of 007 step.

### DIFF
--- a/templates/gromacs/007.colvars.template
+++ b/templates/gromacs/007.colvars.template
@@ -102,7 +102,6 @@ colvar {
     extendedLagrangian      on
     extendedFluctuation     $r_width
     distance {
-        forceNoPBC          yes
         group1 { 
             indexGroup      $protein_selection
         }

--- a/templates/gromacs/BFEEGromacs.py
+++ b/templates/gromacs/BFEEGromacs.py
@@ -898,7 +898,7 @@ class BFEEGromacs:
                         r_width=r_width,
                         r_lower_boundary=r_lower_boundary,
                         r_upper_boundary=r_upper_boundary,
-                        r_wall_constant=0.8368,
+                        r_wall_constant=0.5*4.184,
                         ligand_selection='BFEE_Ligand',
                         protein_selection='BFEE_Protein',
                         protein_center=protein_center_str)
@@ -907,9 +907,10 @@ class BFEEGromacs:
         # write the solvent molecules
         self.solvent.write(posixpath.join(generate_basename, 'solvent.gro'))
         # generate the shell script for making the tpr file
-        new_box_x = np.around(convert(self.system.dimensions[0], 'angstrom', 'nm'), 2) + r_upper_shift
-        new_box_y = np.around(convert(self.system.dimensions[1], 'angstrom', 'nm'), 2) + r_upper_shift
-        new_box_z = np.around(convert(self.system.dimensions[2], 'angstrom', 'nm'), 2) + r_upper_shift
+        # further enlarge the water box by 10% since the size of box may be compressed under NPT
+        new_box_x = np.around(convert(self.system.dimensions[0], 'angstrom', 'nm'), 2) + r_upper_shift * 1.1
+        new_box_y = np.around(convert(self.system.dimensions[1], 'angstrom', 'nm'), 2) + r_upper_shift * 1.1
+        new_box_z = np.around(convert(self.system.dimensions[2], 'angstrom', 'nm'), 2) + r_upper_shift * 1.1
         generateShellScript(f'{sys.path[0]}/templates/gromacs/007.generate_tpr_sh.template',
                             posixpath.join(generate_basename, '007_generate_tpr'),
                             logger=self.logger,


### PR DESCRIPTION
1. Remove forceNoPBC since this option may be problematic in GROMACS.
2. Increase the water box by an extra margin of 10%.
3. Increase the wall constant of r, the displacement between the ligand
and the protein.
4. Use unix-style line endings for BFEEGromacs.py.