### PR TITLE
Fix using base directory filename with spaces.

### DIFF
--- a/templates/gromacs/000.generate_tpr_sh.template
+++ b/templates/gromacs/000.generate_tpr_sh.template
@@ -17,7 +17,7 @@ GRO_FILE=$GRO_FILE_TEMPLATE
 TOP_FILE=$TOP_FILE_TEMPLATE
 
 # generate the tpr file
-OUTPUT_BASENAME=$(basename $(pwd))
+OUTPUT_BASENAME=$(basename "$(pwd)")
 TPR_FILE="$OUTPUT_BASENAME.tpr"
 NEW_MDP_FILE="$OUTPUT_BASENAME.mdp"
 echo "Making gromacs tpr file ($TPR_FILE)..."

--- a/templates/gromacs/001.generate_tpr_sh.template
+++ b/templates/gromacs/001.generate_tpr_sh.template
@@ -17,7 +17,7 @@ GRO_FILE=$GRO_FILE_TEMPLATE
 TOP_FILE=$TOP_FILE_TEMPLATE
 
 # generate the tpr file
-OUTPUT_BASENAME=$(basename $(pwd))
+OUTPUT_BASENAME=$(basename "$(pwd)")
 TPR_FILE="$OUTPUT_BASENAME.tpr"
 NEW_MDP_FILE="$OUTPUT_BASENAME.mdp"
 echo "Making gromacs tpr file ($TPR_FILE)..."

--- a/templates/gromacs/002.generate_tpr_sh.template
+++ b/templates/gromacs/002.generate_tpr_sh.template
@@ -17,7 +17,7 @@ GRO_FILE=$GRO_FILE_TEMPLATE
 TOP_FILE=$TOP_FILE_TEMPLATE
 
 # generate the tpr file
-OUTPUT_BASENAME=$(basename $(pwd))
+OUTPUT_BASENAME=$(basename "$(pwd)")
 TPR_FILE="$OUTPUT_BASENAME.tpr"
 NEW_MDP_FILE="$OUTPUT_BASENAME.mdp"
 echo "Making gromacs tpr file ($TPR_FILE)..."

--- a/templates/gromacs/003.generate_tpr_sh.template
+++ b/templates/gromacs/003.generate_tpr_sh.template
@@ -17,7 +17,7 @@ GRO_FILE=$GRO_FILE_TEMPLATE
 TOP_FILE=$TOP_FILE_TEMPLATE
 
 # generate the tpr file
-OUTPUT_BASENAME=$(basename $(pwd))
+OUTPUT_BASENAME=$(basename "$(pwd)")
 TPR_FILE="$OUTPUT_BASENAME.tpr"
 NEW_MDP_FILE="$OUTPUT_BASENAME.mdp"
 echo "Making gromacs tpr file ($TPR_FILE)..."

--- a/templates/gromacs/004.generate_tpr_sh.template
+++ b/templates/gromacs/004.generate_tpr_sh.template
@@ -17,7 +17,7 @@ GRO_FILE=$GRO_FILE_TEMPLATE
 TOP_FILE=$TOP_FILE_TEMPLATE
 
 # generate the tpr file
-OUTPUT_BASENAME=$(basename $(pwd))
+OUTPUT_BASENAME=$(basename "$(pwd)")
 TPR_FILE="$OUTPUT_BASENAME.tpr"
 NEW_MDP_FILE="$OUTPUT_BASENAME.mdp"
 echo "Making gromacs tpr file ($TPR_FILE)..."

--- a/templates/gromacs/005.generate_tpr_sh.template
+++ b/templates/gromacs/005.generate_tpr_sh.template
@@ -17,7 +17,7 @@ GRO_FILE=$GRO_FILE_TEMPLATE
 TOP_FILE=$TOP_FILE_TEMPLATE
 
 # generate the tpr file
-OUTPUT_BASENAME=$(basename $(pwd))
+OUTPUT_BASENAME=$(basename "$(pwd)")
 TPR_FILE="$OUTPUT_BASENAME.tpr"
 NEW_MDP_FILE="$OUTPUT_BASENAME.mdp"
 echo "Making gromacs tpr file ($TPR_FILE)..."

--- a/templates/gromacs/006.generate_tpr_sh.template
+++ b/templates/gromacs/006.generate_tpr_sh.template
@@ -17,7 +17,7 @@ GRO_FILE=$GRO_FILE_TEMPLATE
 TOP_FILE=$TOP_FILE_TEMPLATE
 
 # generate the tpr file
-OUTPUT_BASENAME=$(basename $(pwd))
+OUTPUT_BASENAME=$(basename "$(pwd)")
 TPR_FILE="$OUTPUT_BASENAME.tpr"
 NEW_MDP_FILE="$OUTPUT_BASENAME.mdp"
 echo "Making gromacs tpr file ($TPR_FILE)..."

--- a/templates/gromacs/007.generate_tpr_sh.template
+++ b/templates/gromacs/007.generate_tpr_sh.template
@@ -17,7 +17,7 @@ GRO_FILE=$GRO_FILE_TEMPLATE
 TOP_FILE=$TOP_FILE_TEMPLATE
 
 # generate the tpr file
-OUTPUT_BASENAME=$(basename $(pwd))
+OUTPUT_BASENAME=$(basename "$(pwd)")
 TPR_FILE="$OUTPUT_BASENAME.tpr"
 NEW_MDP_FILE="$OUTPUT_BASENAME.mdp"
 echo "Making gromacs tpr file ($TPR_FILE)..."

--- a/templates/gromacs/007_eq.generate_tpr_sh.template
+++ b/templates/gromacs/007_eq.generate_tpr_sh.template
@@ -27,7 +27,7 @@ echo "Add more solvent molecules to fill the box..."
 $GMX_BIN solvate -cp $BOX_MODIFIED_GRO_TEMPLATE -cs solvent.gro -p $NEW_TOP_FILE -box $NEW_BOX_X_TEMPLATE $NEW_BOX_Y_TEMPLATE $NEW_BOX_Z_TEMPLATE -o $NEW_GRO_FILE
 
 # generate the tpr file for minimization
-OUTPUT_BASENAME=$(basename $(pwd))
+OUTPUT_BASENAME=$(basename "$(pwd)")
 MIN_MDP_FILE=$MIN_MDP_FILE_TEMPLATE
 MIN_TPR_FILE="$OUTPUT_BASENAME.min.tpr"
 NEW_MIN_MDP_FILE="$OUTPUT_BASENAME.min.new.mdp"
@@ -40,7 +40,7 @@ DEFAULT_OUTPUT_FILENAME="output_minimization/$OUTPUT_BASENAME.min.out"
 $GMX_BIN mdrun -s $MIN_TPR_FILE -deffnm $DEFAULT_OUTPUT_FILENAME
 
 # generate the tpr file
-OUTPUT_BASENAME=$(basename $(pwd))
+OUTPUT_BASENAME=$(basename "$(pwd)")
 TPR_FILE="$OUTPUT_BASENAME.tpr"
 NEW_MDP_FILE="$OUTPUT_BASENAME.mdp"
 NEW_GRO_FILE="$DEFAULT_OUTPUT_FILENAME.gro"

--- a/templates/gromacs/008.generate_tpr_sh.template
+++ b/templates/gromacs/008.generate_tpr_sh.template
@@ -17,7 +17,7 @@ GRO_FILE=$GRO_FILE_TEMPLATE
 TOP_FILE=$TOP_FILE_TEMPLATE
 
 # generate the tpr file
-OUTPUT_BASENAME=$(basename $(pwd))
+OUTPUT_BASENAME=$(basename "$(pwd)")
 TPR_FILE="$OUTPUT_BASENAME.tpr"
 NEW_MDP_FILE="$OUTPUT_BASENAME.mdp"
 echo "Making gromacs tpr file ($TPR_FILE)..."

--- a/templates/gromacs/008_eq.generate_tpr_sh.template
+++ b/templates/gromacs/008_eq.generate_tpr_sh.template
@@ -17,7 +17,7 @@ GRO_FILE=$GRO_FILE_TEMPLATE
 TOP_FILE=$TOP_FILE_TEMPLATE
 
 # generate the tpr file
-OUTPUT_BASENAME=$(basename $(pwd))
+OUTPUT_BASENAME=$(basename "$(pwd)")
 TPR_FILE="$OUTPUT_BASENAME.tpr"
 NEW_MDP_FILE="$OUTPUT_BASENAME.mdp"
 echo "Making gromacs tpr file ($TPR_FILE)..."


### PR DESCRIPTION
$(basename $(pwd)) cannot handle directory names with spaces correctly.
This commit fixes it by quoting the paths.