### PR TITLE
Use centerToOrigin for euler and polar angles.

### DIFF
--- a/BFEE2/templates_gromacs/002.colvars.template
+++ b/BFEE2/templates_gromacs/002.colvars.template
@@ -23,8 +23,9 @@ colvar {
     eulerTheta {
         atoms {
             indexGroup          $ligand_selection
-            centerReference     on
-            rotateReference     on
+            centerToReference   on
+            rotateToReference   on
+            centerToOrigin      on
             enableFitGradients  on
             fittingGroup {
                 indexGroup $protein_selection

--- a/BFEE2/templates_gromacs/003.colvars.template
+++ b/BFEE2/templates_gromacs/003.colvars.template
@@ -17,8 +17,9 @@ colvar {
     eulerTheta {
         atoms {
             indexGroup          $ligand_selection
-            centerReference     on
-            rotateReference     on
+            centerToReference   on
+            rotateToReference   on
+            centerToOrigin      on
             enableFitGradients  on
             fittingGroup {
                 indexGroup $protein_selection
@@ -40,8 +41,9 @@ colvar {
     eulerPhi {
         atoms {
             indexGroup          $ligand_selection
-            centerReference     on
-            rotateReference     on
+            centerToReference   on
+            rotateToReference   on
+            centerToOrigin      on
             enableFitGradients  on
             fittingGroup {
                 indexGroup $protein_selection

--- a/BFEE2/templates_gromacs/004.colvars.template
+++ b/BFEE2/templates_gromacs/004.colvars.template
@@ -17,8 +17,9 @@ colvar {
     eulerTheta {
         atoms {
             indexGroup          $ligand_selection
-            centerReference     on
-            rotateReference     on
+            centerToReference   on
+            rotateToReference   on
+            centerToOrigin      on
             enableFitGradients  on
             fittingGroup {
                 indexGroup $protein_selection
@@ -34,8 +35,9 @@ colvar {
     eulerPhi {
         atoms {
             indexGroup          $ligand_selection
-            centerReference     on
-            rotateReference     on
+            centerToReference   on
+            rotateToReference   on
+            centerToOrigin      on
             enableFitGradients  on
             fittingGroup {
                 indexGroup $protein_selection
@@ -57,8 +59,9 @@ colvar {
     eulerPsi {
         atoms {
             indexGroup          $ligand_selection
-            centerReference     on
-            rotateReference     on
+            centerToReference   on
+            rotateToReference   on
+            centerToOrigin      on
             enableFitGradients  on
             fittingGroup {
                 indexGroup $protein_selection

--- a/BFEE2/templates_gromacs/005.colvars.template
+++ b/BFEE2/templates_gromacs/005.colvars.template
@@ -17,8 +17,9 @@ colvar {
     eulerTheta {
         atoms {
             indexGroup          $ligand_selection
-            centerReference     on
-            rotateReference     on
+            centerToReference   on
+            rotateToReference   on
+            centerToOrigin      on
             enableFitGradients  on
             fittingGroup {
                 indexGroup $protein_selection
@@ -34,8 +35,9 @@ colvar {
     eulerPhi {
         atoms {
             indexGroup          $ligand_selection
-            centerReference     on
-            rotateReference     on
+            centerToReference   on
+            rotateToReference   on
+            centerToOrigin      on
             enableFitGradients  on
             fittingGroup {
                 indexGroup $protein_selection
@@ -51,8 +53,9 @@ colvar {
     eulerPsi {
         atoms {
             indexGroup          $ligand_selection
-            centerReference     on
-            rotateReference     on
+            centerToReference   on
+            rotateToReference   on
+            centerToOrigin      on
             enableFitGradients  on
             fittingGroup {
                 indexGroup $protein_selection
@@ -73,9 +76,10 @@ colvar {
     extendedFluctuation     $polarTheta_width
     polarTheta {
         atoms {
-            indexGroup      $ligand_selection
-            centerReference on
-            rotateReference on
+            indexGroup        $ligand_selection
+            centerToReference on
+            rotateToReference on
+            centerToOrigin    on
             fittingGroup {
                 indexGroup $protein_selection
             }

--- a/BFEE2/templates_gromacs/006.colvars.template
+++ b/BFEE2/templates_gromacs/006.colvars.template
@@ -17,8 +17,9 @@ colvar {
     eulerTheta {
         atoms {
             indexGroup          $ligand_selection
-            centerReference     on
-            rotateReference     on
+            centerToReference   on
+            rotateToReference   on
+            centerToOrigin      on
             enableFitGradients  on
             fittingGroup {
                 indexGroup $protein_selection
@@ -34,8 +35,9 @@ colvar {
     eulerPhi {
         atoms {
             indexGroup          $ligand_selection
-            centerReference     on
-            rotateReference     on
+            centerToReference   on
+            rotateToReference   on
+            centerToOrigin      on
             enableFitGradients  on
             fittingGroup {
                 indexGroup $protein_selection
@@ -51,8 +53,9 @@ colvar {
     eulerPsi {
         atoms {
             indexGroup          $ligand_selection
-            centerReference     on
-            rotateReference     on
+            centerToReference   on
+            rotateToReference   on
+            centerToOrigin      on
             enableFitGradients  on
             fittingGroup {
                 indexGroup $protein_selection
@@ -67,9 +70,10 @@ colvar {
     name polarTheta
     polarTheta {
         atoms {
-            indexGroup      $ligand_selection
-            centerReference on
-            rotateReference on
+            indexGroup        $ligand_selection
+            centerToReference on
+            rotateToReference on
+            centerToOrigin    on
             fittingGroup {
                 indexGroup $protein_selection
             }
@@ -88,9 +92,10 @@ colvar {
     extendedFluctuation     $polarPhi_width
     polarPhi {
         atoms {
-            indexGroup      $ligand_selection
-            centerReference on
-            rotateReference on
+            indexGroup        $ligand_selection
+            centerToReference on
+            rotateToReference on
+            centerToOrigin    on
             fittingGroup {
                 indexGroup $protein_selection
             }

--- a/BFEE2/templates_gromacs/007.colvars.template
+++ b/BFEE2/templates_gromacs/007.colvars.template
@@ -17,8 +17,9 @@ colvar {
     eulerTheta {
         atoms {
             indexGroup          $ligand_selection
-            centerReference     on
-            rotateReference     on
+            centerToReference   on
+            rotateToReference   on
+            centerToOrigin      on
             enableFitGradients  on
             fittingGroup {
                 indexGroup $protein_selection
@@ -34,8 +35,9 @@ colvar {
     eulerPhi {
         atoms {
             indexGroup          $ligand_selection
-            centerReference     on
-            rotateReference     on
+            centerToReference   on
+            rotateToReference   on
+            centerToOrigin      on
             enableFitGradients  on
             fittingGroup {
                 indexGroup $protein_selection
@@ -51,8 +53,9 @@ colvar {
     eulerPsi {
         atoms {
             indexGroup          $ligand_selection
-            centerReference     on
-            rotateReference     on
+            centerToReference   on
+            rotateToReference   on
+            centerToOrigin      on
             enableFitGradients  on
             fittingGroup {
                 indexGroup $protein_selection
@@ -67,9 +70,10 @@ colvar {
     name polarTheta
     polarTheta {
         atoms {
-            indexGroup      $ligand_selection
-            centerReference on
-            rotateReference on
+            indexGroup        $ligand_selection
+            centerToReference on
+            rotateToReference on
+            centerToOrigin    on
             fittingGroup {
                 indexGroup $protein_selection
             }
@@ -82,9 +86,10 @@ colvar {
     name                    polarPhi
     polarPhi {
         atoms {
-            indexGroup      $ligand_selection
-            centerReference on
-            rotateReference on
+            indexGroup        $ligand_selection
+            centerToReference on
+            rotateToReference on
+            centerToOrigin    on
             fittingGroup {
                 indexGroup  $protein_selection
             }

--- a/BFEE2/templates_gromacs/007_eq.colvars.template
+++ b/BFEE2/templates_gromacs/007_eq.colvars.template
@@ -17,8 +17,9 @@ colvar {
     eulerTheta {
         atoms {
             indexGroup          $ligand_selection
-            centerReference     on
-            rotateReference     on
+            centerToReference   on
+            rotateToReference   on
+            centerToOrigin      on
             enableFitGradients  on
             fittingGroup {
                 indexGroup $protein_selection
@@ -34,8 +35,9 @@ colvar {
     eulerPhi {
         atoms {
             indexGroup          $ligand_selection
-            centerReference     on
-            rotateReference     on
+            centerToReference   on
+            rotateToReference   on
+            centerToOrigin      on
             enableFitGradients  on
             fittingGroup {
                 indexGroup $protein_selection
@@ -51,8 +53,9 @@ colvar {
     eulerPsi {
         atoms {
             indexGroup          $ligand_selection
-            centerReference     on
-            rotateReference     on
+            centerToReference   on
+            rotateToReference   on
+            centerToOrigin      on
             enableFitGradients  on
             fittingGroup {
                 indexGroup $protein_selection
@@ -67,9 +70,10 @@ colvar {
     name polarTheta
     polarTheta {
         atoms {
-            indexGroup      $ligand_selection
-            centerReference on
-            rotateReference on
+            indexGroup        $ligand_selection
+            centerToReference on
+            rotateToReference on
+            centerToOrigin    on
             fittingGroup {
                 indexGroup $protein_selection
             }
@@ -82,9 +86,10 @@ colvar {
     name                    polarPhi
     polarPhi {
         atoms {
-            indexGroup      $ligand_selection
-            centerReference on
-            rotateReference on
+            indexGroup        $ligand_selection
+            centerToReference on
+            rotateToReference on
+            centerToOrigin    on
             fittingGroup {
                 indexGroup  $protein_selection
             }


### PR DESCRIPTION
Colvars requires to bring the starting point of the vector to the origin
for correctly measuring the polar angles.