### PR TITLE
GROMACS: Use Parrinello-Rahman barostat

### DIFF
--- a/BFEE2/gui.py
+++ b/BFEE2/gui.py
@@ -1819,11 +1819,15 @@ Unknown error! The error message is: \n\
 
             # gromacs
             if self.preTreatmentMainTabs.currentIndex() == 1:
-
+                
                 QMessageBox.warning(
-                    self, 'Warning', f'Any setting in "Advanced settings" is not supported \n\
-when using Gromacs-formatted files as inputs!'
-                )
+                    self, 'Warning', ('<ol>\
+                  <li>Any setting in "Advanced settings" is not supported\
+                      when using Gromacs-formatted files as inputs!</li>\
+                   <li>C-rescale pressure coupling (pcoupl) is used for all simulations, \
+                      GROMACS version >= 2021 with Colvars module is required. \
+                      You may need to download it from the \
+                      <a href=\'https://github.com/Colvars/colvars/\'>Colvars website</a>.</li></ol>'))
 
                 for item in [
                         self.topLineEdit.text(), 

--- a/BFEE2/templates_gromacs/000.mdp.template
+++ b/BFEE2/templates_gromacs/000.mdp.template
@@ -53,7 +53,7 @@ implicit-solvent    = no
 
 ;Pressure coupling
 ;Pressure coupling
-pcoupl              = Parrinello-Rahman
+pcoupl              = C-rescale
 pcoupltype          = Isotropic
 nstpcouple          = -1
 tau-p               = 2

--- a/BFEE2/templates_gromacs/000.mdp.template
+++ b/BFEE2/templates_gromacs/000.mdp.template
@@ -53,7 +53,7 @@ implicit-solvent    = no
 
 ;Pressure coupling
 ;Pressure coupling
-pcoupl              = berendsen
+pcoupl              = Parrinello-Rahman
 pcoupltype          = Isotropic
 nstpcouple          = -1
 tau-p               = 2

--- a/BFEE2/templates_gromacs/001.mdp.template
+++ b/BFEE2/templates_gromacs/001.mdp.template
@@ -53,7 +53,7 @@ implicit-solvent    = no
 
 ;Pressure coupling
 ;Pressure coupling
-pcoupl              = Parrinello-Rahman
+pcoupl              = C-rescale
 pcoupltype          = Isotropic
 nstpcouple          = -1
 tau-p               = 2

--- a/BFEE2/templates_gromacs/001.mdp.template
+++ b/BFEE2/templates_gromacs/001.mdp.template
@@ -53,7 +53,7 @@ implicit-solvent    = no
 
 ;Pressure coupling
 ;Pressure coupling
-pcoupl              = berendsen
+pcoupl              = Parrinello-Rahman
 pcoupltype          = Isotropic
 nstpcouple          = -1
 tau-p               = 2

--- a/BFEE2/templates_gromacs/002.mdp.template
+++ b/BFEE2/templates_gromacs/002.mdp.template
@@ -53,7 +53,7 @@ implicit-solvent    = no
 
 ;Pressure coupling
 ;Pressure coupling
-pcoupl              = Parrinello-Rahman
+pcoupl              = C-rescale
 pcoupltype          = Isotropic
 nstpcouple          = -1
 tau-p               = 2

--- a/BFEE2/templates_gromacs/002.mdp.template
+++ b/BFEE2/templates_gromacs/002.mdp.template
@@ -53,7 +53,7 @@ implicit-solvent    = no
 
 ;Pressure coupling
 ;Pressure coupling
-pcoupl              = berendsen
+pcoupl              = Parrinello-Rahman
 pcoupltype          = Isotropic
 nstpcouple          = -1
 tau-p               = 2

--- a/BFEE2/templates_gromacs/003.mdp.template
+++ b/BFEE2/templates_gromacs/003.mdp.template
@@ -53,7 +53,7 @@ implicit-solvent    = no
 
 ;Pressure coupling
 ;Pressure coupling
-pcoupl              = Parrinello-Rahman
+pcoupl              = C-rescale
 pcoupltype          = Isotropic
 nstpcouple          = -1
 tau-p               = 2

--- a/BFEE2/templates_gromacs/003.mdp.template
+++ b/BFEE2/templates_gromacs/003.mdp.template
@@ -53,7 +53,7 @@ implicit-solvent    = no
 
 ;Pressure coupling
 ;Pressure coupling
-pcoupl              = berendsen
+pcoupl              = Parrinello-Rahman
 pcoupltype          = Isotropic
 nstpcouple          = -1
 tau-p               = 2

--- a/BFEE2/templates_gromacs/004.mdp.template
+++ b/BFEE2/templates_gromacs/004.mdp.template
@@ -53,7 +53,7 @@ implicit-solvent    = no
 
 ;Pressure coupling
 ;Pressure coupling
-pcoupl              = Parrinello-Rahman
+pcoupl              = C-rescale
 pcoupltype          = Isotropic
 nstpcouple          = -1
 tau-p               = 2

--- a/BFEE2/templates_gromacs/004.mdp.template
+++ b/BFEE2/templates_gromacs/004.mdp.template
@@ -53,7 +53,7 @@ implicit-solvent    = no
 
 ;Pressure coupling
 ;Pressure coupling
-pcoupl              = berendsen
+pcoupl              = Parrinello-Rahman
 pcoupltype          = Isotropic
 nstpcouple          = -1
 tau-p               = 2

--- a/BFEE2/templates_gromacs/005.mdp.template
+++ b/BFEE2/templates_gromacs/005.mdp.template
@@ -53,7 +53,7 @@ implicit-solvent    = no
 
 ;Pressure coupling
 ;Pressure coupling
-pcoupl              = Parrinello-Rahman
+pcoupl              = C-rescale
 pcoupltype          = Isotropic
 nstpcouple          = -1
 tau-p               = 2

--- a/BFEE2/templates_gromacs/005.mdp.template
+++ b/BFEE2/templates_gromacs/005.mdp.template
@@ -53,7 +53,7 @@ implicit-solvent    = no
 
 ;Pressure coupling
 ;Pressure coupling
-pcoupl              = berendsen
+pcoupl              = Parrinello-Rahman
 pcoupltype          = Isotropic
 nstpcouple          = -1
 tau-p               = 2

--- a/BFEE2/templates_gromacs/006.mdp.template
+++ b/BFEE2/templates_gromacs/006.mdp.template
@@ -53,7 +53,7 @@ implicit-solvent    = no
 
 ;Pressure coupling
 ;Pressure coupling
-pcoupl              = Parrinello-Rahman
+pcoupl              = C-rescale
 pcoupltype          = Isotropic
 nstpcouple          = -1
 tau-p               = 2

--- a/BFEE2/templates_gromacs/006.mdp.template
+++ b/BFEE2/templates_gromacs/006.mdp.template
@@ -53,7 +53,7 @@ implicit-solvent    = no
 
 ;Pressure coupling
 ;Pressure coupling
-pcoupl              = berendsen
+pcoupl              = Parrinello-Rahman
 pcoupltype          = Isotropic
 nstpcouple          = -1
 tau-p               = 2

--- a/BFEE2/templates_gromacs/007.mdp.template
+++ b/BFEE2/templates_gromacs/007.mdp.template
@@ -52,7 +52,7 @@ morse                   = no
 implicit-solvent    = no
 
 ;Pressure coupling
-pcoupl              = berendsen
+pcoupl              = Parrinello-Rahman
 pcoupltype          = Isotropic
 nstpcouple          = -1
 tau-p               = 2

--- a/BFEE2/templates_gromacs/007.mdp.template
+++ b/BFEE2/templates_gromacs/007.mdp.template
@@ -52,7 +52,7 @@ morse                   = no
 implicit-solvent    = no
 
 ;Pressure coupling
-pcoupl              = Parrinello-Rahman
+pcoupl              = C-rescale
 pcoupltype          = Isotropic
 nstpcouple          = -1
 tau-p               = 2

--- a/BFEE2/templates_gromacs/008.mdp.template
+++ b/BFEE2/templates_gromacs/008.mdp.template
@@ -53,7 +53,7 @@ implicit-solvent    = no
 
 ;Pressure coupling
 ;Pressure coupling
-pcoupl              = Parrinello-Rahman
+pcoupl              = C-rescale
 pcoupltype          = Isotropic
 nstpcouple          = -1
 tau-p               = 2

--- a/BFEE2/templates_gromacs/008.mdp.template
+++ b/BFEE2/templates_gromacs/008.mdp.template
@@ -53,7 +53,7 @@ implicit-solvent    = no
 
 ;Pressure coupling
 ;Pressure coupling
-pcoupl              = berendsen
+pcoupl              = Parrinello-Rahman
 pcoupltype          = Isotropic
 nstpcouple          = -1
 tau-p               = 2


### PR DESCRIPTION
New versions of GMX deprecate the use of Berendsen barostat.

This commit should solve the problem mentioned in #96.