### PR TITLE
Add SOL residue name to water selection for Gromacs

### DIFF
--- a/BFEE2/inputGenerator.py
+++ b/BFEE2/inputGenerator.py
@@ -241,7 +241,7 @@ class inputGenerator():
         ligandOnlyPdbFileFormat,
         selectionPro,
         selectionLig,
-        selectionSol='resname TIP3* or resname SPC* or resname HOH or resname WAT',
+        selectionSol='resname TIP3* or resname SPC* or resname HOH or resname WAT or resname SOL',
         temperature=300.0
     ):
         """generate all the input files for Gromacs Geometric simulation


### PR DESCRIPTION
Hello, 

In some structure files such as those with a '.pdb' or '.gro' extension, the name of the water residue is specified as SOL. So, I included this residue name in the solvent selection variable `selectionSol`.

Thanks,
Nazanin 