### PR TITLE
fix: use fit gradients for default

### DIFF
--- a/BFEE2/templates_namd/configTemplate.py
+++ b/BFEE2/templates_namd/configTemplate.py
@@ -566,7 +566,6 @@ colvar {{                              \n\
             indexGroup  ligand                 \n\
             centerReference    on              \n\
             rotateReference    on              \n\
-	        enableFitGradients no              \n\
             fittingGroup {{                    \n\
                 indexGroup  protein            \n\
             }}                                 \n\
@@ -637,7 +636,6 @@ colvar {{                                   \n\
             indexGroup  reference           \n\
             centerReference    on           \n\
             rotateReference    on           \n\
-            enableFitGradients no           \n\
             fittingGroup {{                 \n\
                 indexGroup  protein         \n\
             }}                              \n\
@@ -647,7 +645,6 @@ colvar {{                                   \n\
             indexGroup  ligand              \n\
             centerReference    on           \n\
             rotateReference    on           \n\
-            enableFitGradients no           \n\
             fittingGroup {{                 \n\
                 indexGroup  protein         \n\
             }}                              \n\
@@ -707,7 +704,6 @@ colvar {{                              \n\
             centerReference    on              \n\
             rotateReference    on              \n\
             centerToOrigin     on              \n\
-	        enableFitGradients on              \n\
             fittingGroup {{                    \n\
                 indexGroup  protein            \n\
             }}                                 \n\


### PR DESCRIPTION
https://github.com/Colvars/colvars/pull/713 has been merged and the "fit gradients" for non-scalar variables (or more accurately, the forces on the fitting group) are available.