### PR TITLE
Fix WTM hillWidth for GROMACS geometric route

### DIFF
--- a/BFEE2/templates_gromacs/001.colvars.template
+++ b/BFEE2/templates_gromacs/001.colvars.template
@@ -35,7 +35,7 @@ abf {
 
 metadynamics {
     colvars             RMSD
-    hillWidth           $rmsd_bin_width
+    hillWidth           3.0
     hillWeight          0.2092
     wellTempered        on
     biasTemperature     4000


### PR DESCRIPTION
Dear BFEE authors,

Thank you for the amazing BFEE package. I would like to discuss the following about GROMACS geometrical route.

For Step 001, the WTM gaussian `hillWidth` is set to `$rmsd_bin_width`. According to [Colvars documentation](https://colvars.github.io/master/colvars-refman-gromacs.html#sec:colvarbias_meta), `hillWidth` should be in units of `width`.

Value `3.0` is used for Step 002-007, which should be good in general. However, current setting for Step 001, `$rmsd_bin_width`, is way too small typically. This will lead to WTM to be basically inactive, as the added gaussians are too narrow to fill up basins. Such narrow spikes may also cause abnormal forces and numerical instabilities.

With the current settings, Colvars will emit the follow warning on mdrun start:

```text
colvars:   Initializing a new "metadynamics" instance.
...
colvars:   Warning: gaussianSigmas is too narrow for the grid spacing along RMSD.
...
```

In my opinion, maybe `3.0` is also a good value for Step 001?

Look forward to your reply. Thanks again for your great contributions to the field!

Best,
Ye